### PR TITLE
add possibility to set options on transformation object instance

### DIFF
--- a/Classes/ExternalConfigurationManager.php
+++ b/Classes/ExternalConfigurationManager.php
@@ -15,11 +15,12 @@ class ExternalConfigurationManager
 
     /**
      * @param ConfigurationManager $configurationManager
+     * @param bool $force Force applying and refresh configuration
      * @return void
      * @throws \Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException
      * @throws Exception
      */
-    public function process(ConfigurationManager $configurationManager)
+    public function process(ConfigurationManager $configurationManager, $force = false)
     {
         $externalConfigurationConfig = $configurationManager->getConfiguration(
             ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
@@ -32,10 +33,34 @@ class ExternalConfigurationManager
 
         // only load and process external configuration if directive existent
         $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS);
-        if ($this->hasExternalConfigurationDirective($settings)) {
+        if ($this->hasExternalConfigurationDirective($settings) || $force) {
             $this->loadExternalConfiguration($externalConfigurationConfig);
             $this->applyExternalConfiguration($configurationManager);
         }
+    }
+
+    /**
+     * @param ConfigurationManager $configurationManager
+     * @param string|null $configurationPath
+     * @return array|mixed|null
+     * @throws Exception
+     */
+    public function getExternalConfiguration(ConfigurationManager $configurationManager, string $configurationPath = null)
+    {
+        if (empty($this->externalConfiguration)) {
+            $externalConfigurationConfig = $configurationManager->getConfiguration(
+                ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
+                'Sandstorm.ConfigLoader.externalConfig');
+
+            $this->loadExternalConfiguration($externalConfigurationConfig);
+        }
+
+        $configuration = $this->externalConfiguration;
+        if ($configurationPath === null) {
+            return $configuration;
+        }
+
+        return (Arrays::getValueByPath($configuration, $configurationPath));
     }
 
     /**

--- a/Classes/ExternalConfigurationManager.php
+++ b/Classes/ExternalConfigurationManager.php
@@ -150,7 +150,8 @@ class ExternalConfigurationManager
             }
             if (is_string($value)) {
                 $result = preg_match(self::EXTERNAL_CONFIGURATION_PATTERN, $value);
-                if ($result === 1) {
+                $hasDirective = $result === 1;
+                if ($hasDirective) {
                     break;
                 }
             }

--- a/Classes/ExternalConfigurationManager.php
+++ b/Classes/ExternalConfigurationManager.php
@@ -64,8 +64,13 @@ class ExternalConfigurationManager
                     throw new Exception(sprintf("The class %s does not exist or does not implement TransformationInterface.", $transformationClass));
                 }
 
+                $transformationOptions = array_key_exists('transformationOptions', $externalConfigElement) ? $externalConfigElement['transformationOptions'] : null;
+
                 /** @var TransformationInterface $transformation */
                 $transformation = new $transformationClass();
+                if (is_array($transformationOptions)) {
+                    $transformation->setOptions($transformationOptions);
+                }
                 $configuration = $transformation->transform($configuration);
             }
 

--- a/Classes/Transformation/JsonTransformation.php
+++ b/Classes/Transformation/JsonTransformation.php
@@ -13,4 +13,7 @@ class JsonTransformation implements TransformationInterface
         return json_decode($rawConfiguration, true);
     }
 
+    public function setOptions(array $options): void
+    {
+    }
 }

--- a/Classes/Transformation/TransformationInterface.php
+++ b/Classes/Transformation/TransformationInterface.php
@@ -13,4 +13,11 @@ interface TransformationInterface
      * @return mixed
      */
     public function transform($rawConfiguration);
+
+    /**
+     * Set transformation options
+     *
+     * @param array $options
+     */
+    public function setOptions(array $options): void;
 }


### PR DESCRIPTION
This change adds the possibility to set options on transformation object.

This change is breaking, because it adds a new method to `TransformationInterface`

There was a bug when applying external configuration. Configuration values with env vars such as `'%env:MY_ENV_VAR%` were replaced with already proccessed value (result of `getenv('MY_ENV_VAR')`)